### PR TITLE
fixed not found errors

### DIFF
--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -30,6 +30,7 @@ Feature: Test duplicating a quiz containing an Algebra question
       | Schema | Course name | Course 2 |
     And I navigate to "Question bank" in current page administration
     And I click on "Edit" "link" in the "Algebra question" "table_row"
+    And I click on "Edit question" "link" in the "Algebra question" "table_row"
     Then the following fields match these values:
       | Question name        | Algebra question                                  |
       | Question text        | P(x) = 3x and Q(x) = 4x. Calculate (P + Q)(x)     |

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -27,6 +27,7 @@ Feature: Test editing an Algebra question
   @javascript @_switch_window
   Scenario: Edit an Algebra question
     When I click on "Edit" "link" in the "algebra-001 for editing" "table_row"
+    And I click on "Edit question" "link" in the "algebra-001 for editing" "table_row"
     And I set the following fields to these values:
       | Question name | |
     And I press "id_submitbutton"
@@ -36,6 +37,7 @@ Feature: Test editing an Algebra question
     And I press "id_submitbutton"
     Then I should see "Edited algebra-001 name"
     When I click on "Edit" "link" in the "Edited algebra-001 name" "table_row"
+    And I click on "Edit question" "link" in the "Edited algebra-001 name" "table_row"
     And I press "id_addanswers"
     And I set the following fields to these values:
       | id_answer_1          | 6*x                        |
@@ -43,6 +45,7 @@ Feature: Test editing an Algebra question
       | id_feedback_1        | 3x + 4x gives 7x not 6x.   |
     And I press "id_submitbutton"
     Then I should see "Edited algebra-001 name"
+    When I click on "Edit" "link" in the "Edited algebra-001 name" "table_row"
     When I click on "Preview" "link" in the "Edited algebra-001 name" "table_row"
     And I switch to "questionpreview" window
     Then I should see "P(x) = 3x and Q(x) = 4x. Calculate (P + Q)(x)"

--- a/tests/behat/preview.feature
+++ b/tests/behat/preview.feature
@@ -26,6 +26,7 @@ Feature: Preview an Algebra question
 
   @javascript @_switch_window
   Scenario: Preview an Algebra question with correct answer
+    When I click on "Edit" "link" in the "algebra-001" "table_row"	       
     When I click on "Preview" "link" in the "algebra-001" "table_row"
     And I switch to "questionpreview" window
     Then I should see "P(x) = 3x and Q(x) = 4x. Calculate (P + Q)(x)"
@@ -42,6 +43,7 @@ Feature: Preview an Algebra question
 
   @javascript @_switch_window
   Scenario: Preview an Algebra question with incorrect answer
+    When I click on "Edit" "link" in the "algebra-001" "table_row"		
     When I click on "Preview" "link" in the "algebra-001" "table_row"
     And I switch to "questionpreview" window
     Then I should see "P(x) = 3x and Q(x) = 4x. Calculate (P + Q)(x)"


### PR DESCRIPTION
023 Scenario: Backup and restore a course containing an algebra question # /var/www/html/question/type/algebra/tests/behat/backup_and_restore.feature:26
      Then the following fields match these values:                      # /var/www/html/question/type/algebra/tests/behat/backup_and_restore.feature:33
        Field matching locator "Question name" not found. (Behat\Mink\Exception\ElementNotFoundException)
***************************
063 Scenario: Edit an Algebra question                # /var/www/html/question/type/algebra/tests/behat/edit.feature:28
      And I set the following fields to these values: # /var/www/html/question/type/algebra/tests/behat/edit.feature:30
        Field matching locator "Question name" not found. (Behat\Mink\Exception\ElementNotFoundException)
******************************
132 Scenario: Preview an Algebra question with correct answer           # /var/www/html/question/type/algebra/tests/behat/preview.feature:28
      When I click on "Preview" "link" in the "algebra-001" "table_row" # /var/www/html/question/type/algebra/tests/behat/preview.feature:29
        The "((//html/.//tr[contains(normalize-space(.), 'algebra-001') and not(.//tr[contains(normalize-space(.), 'algebra-001')])])[1]/.//a
        [./@href][((./@id = 'Preview' or contains(normalize-space(string(.)), 'Preview') or contains(./@title, 'Preview') or contains(./@rel, 'Preview')) or 
.//*[(contains(concat(' ', @class, ' '), ' icon ') or name() = 'img') and (contains(./@alt, 'Preview') or contains(./@title, 'Preview'))])] | (//html/.//tr[contains(normalize-space(.), 
'algebra-001') and not(.//tr[contains(normalize-space(.), 'algebra-001')])])[1]/.//*
        [translate(./@role, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'link'][((./@id = 'Preview' or contains(./@value, 'Preview')) or contains(./@title, 
'Preview') or contains(normalize-space(string(.)), 'Preview'))])[1]" xpath node is not visible and it should be visible (Behat\Mink\Exception\ExpectationException)
********************************
133 Scenario: Preview an Algebra question with incorrect answer         # /var/www/html/question/type/algebra/tests/behat/preview.feature:44
      When I click on "Preview" "link" in the "algebra-001" "table_row" # /var/www/html/question/type/algebra/tests/behat/preview.feature:45
        The "((//html/.//tr[contains(normalize-space(.), 'algebra-001') and not(.//tr[contains(normalize-space(.), 'algebra-001')])])[1]/.//a
        [./@href][((./@id = 'Preview' or contains(normalize-space(string(.)), 'Preview') or contains(./@title, 'Preview') or contains(./@rel, 'Preview')) or .//*[(contains(concat
(' ', @class, ' '), ' icon ') or name() = 'img') and (contains(./@alt, 'Preview') or contains(./@title, 'Preview'))])] | (//html/.//tr[contains(normalize-space(.), 'algebra-001') 
and not(.//tr[contains(normalize-space(.), 'algebra-001')])])[1]/.//*
        [translate(./@role, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'link'][((./@id = 'Preview' or contains(./@value, 'Preview')) or contains(./@title, 'Preview') 
or contains(normalize-space(string(.)), 'Preview'))])[1]" xpath node is not visible and it should be visible (Behat\Mink\Exception\ExpectationException)