### PR TITLE
Issue #14: Updated questiontype_test to fix failing test

### DIFF
--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -108,14 +108,14 @@ class qtype_algebra_test extends advanced_testcase {
         $actualquestiondata = end($actualquestionsdata);
 
         foreach ($questiondata as $property => $value) {
-            if (!in_array($property, array('id', 'version', 'timemodified', 'timecreated', 'options'))) {
-                $this->assertObjectHasAttribute($property, $actualquestiondata);
+            if (!in_array($property, array('id', 'idnumber', 'version', 'timemodified', 'timecreated', 'options'))) {
+                $this->assertObjectHasProperty($property, $actualquestiondata);
             }
         }
 
         foreach ($questiondata->options as $optionname => $value) {
             if (!in_array($optionname, array('answers', 'variables'))) {
-                $this->assertObjectHasAttribute($optionname, $actualquestiondata->options);
+                $this->assertObjectHasProperty($optionname, $actualquestiondata->options);
             }
         }
 
@@ -124,7 +124,7 @@ class qtype_algebra_test extends advanced_testcase {
             foreach ($answer as $ansproperty => $ansvalue) {
                 // This question does not use 'answerformat', will ignore it.
                 if (!in_array($ansproperty, array('id', 'question', 'answerformat'))) {
-                    $this->assertObjectHasAttribute($ansproperty, $actualanswer);
+                    $this->assertObjectHasProperty($ansproperty, $actualanswer);
                 }
             }
         }


### PR DESCRIPTION
Closes Issue #14. 

Added check for `idnumber` in `$property` and update  deprecated call to `assertObjectHasAttribute` to `assertObjectHasProperty`.

After running unit tests with this change: 
```
Moodle 4.5.2+ (Build: 20250311), 2887f0ebcc6719479681e30ee843a682d99d09e2
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-52-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.......                                                             7 / 7 (100%)

Time: 00:02.414, Memory: 97.50 MB

OK (7 tests, 35 assertions)
```